### PR TITLE
Fix groupId in readme com -> org

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ In your <pom.xml> include the following dependency
 
 ```
 <dependency>
-  <groupId>com.mellowtech</groupId>
+  <groupId>org.mellowtech</groupId>
   <artifactId>core</artifactId>
   <version>3.0.3</version>
 </dependency>


### PR DESCRIPTION
the dependecy in README.md use `com.mellowtech`, while it's `org.mellowtech` in pom.xml

I though it was not published to maven central until I did a search for `mellowtech` and found it's `org`
instead of `com`. This is a really big problem for copy and paste guy like me.....

> (•_•)
<)   )╯ 'Cause I just wanna copy and paste
 /    \
  (•_•)
<(   (>   copy and paste
  /    \