### PR TITLE
Added comments and the ability to clear codec mappings

### DIFF
--- a/src/main/java/org/mellowtech/core/codec/Codecs.java
+++ b/src/main/java/org/mellowtech/core/codec/Codecs.java
@@ -23,6 +23,7 @@ import java.util.*;
  * @author Martin Svensson {@literal <msvens@gmail.com>}
  * @since 4.0.0
  */
+@SuppressWarnings("unchecked")
 public class Codecs {
 
   private static BooleanCodec booleanCodec = new BooleanCodec();
@@ -43,10 +44,28 @@ public class Codecs {
   private static Map<Class,BCodec> classCodecs = new HashMap<>();
 
 
-  public static void addMapping(Class<?> clazz, BCodec<?> codec){
+  /**
+   * Add a user defined coded for a class
+   * @param clazz class to add
+   * @param codec codec
+   */
+  public static <A> void addMapping(Class<A> clazz, BCodec<A> codec){
     classCodecs.put(clazz,codec);
   }
 
+  /**
+   * Remove any user defined mappings
+   */
+  public static void clearMappings(){
+    classCodecs.clear();
+  }
+
+  /**
+   * Get codec for an object
+   * @param obj object
+   * @param <A> type
+   * @return codec
+   */
   public static <A> BCodec<A> type(A obj) {
     if (obj instanceof Class)
       return fromClass((Class<A>) obj);
@@ -54,7 +73,14 @@ public class Codecs {
       return fromClass((Class<A>) obj.getClass());
   }
 
-  public static final <A> byte toByte(BCodec<A> codec){
+  /**
+   * Get the byte representation for a specific codec. Will only work
+   * for the built in codeds
+   * @param codec codec
+   * @param <A> type
+   * @return codec number
+   */
+  public static <A> byte toByte(BCodec<A> codec){
     if(codec instanceof BooleanCodec)
       return 1;
     else if(codec instanceof ByteCodec)
@@ -87,7 +113,13 @@ public class Codecs {
       throw new Error("unknown codec");
   }
 
-  public static final <A> BCodec<A> fromByte(byte b){
+  /**
+   * Get the codec represented by this byte
+   * @param b codec
+   * @param <A> type
+   * @return codec
+   */
+  public static <A> BCodec<A> fromByte(byte b){
       if(b == 1)
         return (BCodec<A>) booleanCodec;
       else if(b == 2)
@@ -121,7 +153,13 @@ public class Codecs {
   }
 
 
-  public static final <A> BCodec<A> fromClass(Class<A> clazz){
+  /**
+   * Get the codec for class
+   * @param clazz class
+   * @param <A> type
+   * @return codec
+   */
+  public static <A> BCodec<A> fromClass(Class<A> clazz){
     BCodec codec = classCodecs.get(clazz);
     if(codec != null)
       return (BCodec<A>) codec;

--- a/src/test/java/org/mellowtech/core/codec/CodecsTest.java
+++ b/src/test/java/org/mellowtech/core/codec/CodecsTest.java
@@ -1,23 +1,7 @@
-/*
- * Copyright 2015 mellowtech.org
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.mellowtech.core.codec;
 
 /**
- * @author msvens
+ * @author Martin Svensson
  * @since 2017-01-30
  */
 
@@ -27,15 +11,14 @@ import org.junit.Test;
 public class CodecsTest {
 
   @Test public void getStringCodec(){
-    StringCodec codec = new StringCodec();
     Assert.assertTrue(Codecs.fromClass(String.class) instanceof StringCodec);
-    Assert.assertTrue(Codecs.type(new String()) instanceof StringCodec);
+    Assert.assertTrue(Codecs.type("") instanceof StringCodec);
   }
 
   @Test public void getChangeStringCodec(){
     Codecs.addMapping(String.class, new StringCodec2());
     Assert.assertTrue(Codecs.fromClass(String.class) instanceof StringCodec2);
-    Assert.assertTrue(Codecs.type(new String()) instanceof StringCodec2);
-    Codecs.addMapping(String.class, new StringCodec());
+    Assert.assertTrue(Codecs.type("") instanceof StringCodec2);
+    Codecs.clearMappings();
   }
 }


### PR DESCRIPTION
Codec tests failed because the user defined mappings wasn't properly cleared