### PR TITLE
Compress

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,9 +44,9 @@
             <version>1.7.22</version>
         </dependency>
         <dependency>
-            <groupId>net.jpountz.lz4</groupId>
-            <artifactId>lz4</artifactId>
-            <version>1.3.0</version>
+            <groupId>org.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+            <version>1.4.1</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/org/mellowtech/core/io/compress/BlockPointer.java
+++ b/src/main/java/org/mellowtech/core/io/compress/BlockPointer.java
@@ -1,0 +1,89 @@
+package org.mellowtech.core.io.compress;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+
+/**
+ * @author Martin Svensson
+ * @since 2018-02-10
+ */
+public class BlockPointer {
+
+  private int size;
+  private int origSize;
+  private boolean deleted;
+  private long offset;
+
+  static final int ByteSize = 12;
+
+
+
+  static BlockPointer read(FileChannel fc, long offset) throws IOException{
+    ByteBuffer bb = ByteBuffer.allocate(12);
+    fc.read(bb, offset);
+    return read(bb, 0, offset);
+  }
+
+  static BlockPointer read(ByteBuffer bb, int bufferOffset, long fileOffset) throws IOException{
+    int type = bb.getInt(bufferOffset);
+    int size = bb.getInt(bufferOffset+4);
+    int origSize = bb.getInt(bufferOffset+8);
+    boolean deleted = false;
+    if(type == CFile.DELETED_BLOCK){
+      deleted = true;
+    }
+    else if(type != CFile.BLOCK)
+      throw new IOException("Could not read block");
+    return new BlockPointer(fileOffset, size, origSize, deleted);
+  }
+
+
+  BlockPointer(long offset, int size, int origSize, boolean deleted){
+    this.offset = offset;
+    this.size = size;
+    this.origSize = origSize;
+    this.deleted = deleted;
+  }
+
+  public int getSize() {
+    return size;
+  }
+
+  public int getOrigSize() {
+    return origSize;
+  }
+
+  public boolean isDeleted() {
+    return deleted;
+  }
+
+  public long getOffset() {
+    return offset;
+  }
+
+  public long getDataOffset() {
+    return offset + ByteSize;
+  }
+
+  void write(FileChannel fc, long offset) throws IOException{
+    ByteBuffer bb = ByteBuffer.allocate(12);
+    write(bb, 0);
+    fc.write(bb);
+  }
+
+  void write(ByteBuffer bb, int offset){
+    bb.putInt(offset, deleted ? CFile.DELETED_BLOCK : CFile.BLOCK);
+    bb.putInt(offset+4, size);
+    bb.putInt(offset+8, origSize);
+  }
+
+  public String toString(){
+    return String.format("offset: %d, size: %d, origSize: %d, deleted: %b", offset, size, origSize, deleted);
+    //return "offset: "+offset+"\tsize: "+size+"\torigSize: "+origSize+"\tdeleted: "+deleted;
+  }
+
+
+
+
+}

--- a/src/main/java/org/mellowtech/core/io/compress/CFile.java
+++ b/src/main/java/org/mellowtech/core/io/compress/CFile.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2015 mellowtech.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mellowtech.core.io.compress;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.util.Iterator;
+
+/**
+ * @author msvens
+ * @since 2018-02-10
+ */
+public interface CFile {
+
+  static int BLOCK = 787997538;
+  static int DELETED_BLOCK = 687567531;
+  //static int DEFAULT_BLOCK_SIZE = 64*1024;
+
+  FileChannel fc();
+  Path p();
+
+  default BlockPointer get(long offset) throws IOException{
+    return BlockPointer.read(fc(), offset);
+  }
+
+  default void close() throws IOException {
+    fc().close();
+  }
+
+  default void delete() throws IOException {
+    if(isOpen())
+      close();
+    Files.delete(p());
+  }
+
+  default boolean isOpen(){
+    return fc().isOpen();
+  }
+}
+
+abstract class AbstractCFile implements CFile{
+
+  final Path p;
+  final FileChannel fc;
+
+  AbstractCFile(Path p, OpenOption... options) throws IOException{
+    this.p = p;
+    fc = FileChannel.open(p, options);
+  }
+
+  public Path p(){
+    return p;
+  }
+
+  public FileChannel fc(){
+    return fc;
+  }
+}
+
+
+
+

--- a/src/main/java/org/mellowtech/core/io/compress/CFileBuilder.java
+++ b/src/main/java/org/mellowtech/core/io/compress/CFileBuilder.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2015 mellowtech.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mellowtech.core.io.compress;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * @author msvens
+ * @since 2018-02-24
+ */
+public class CFileBuilder {
+
+  enum Compressor{LZ4};
+
+
+  private int DEFAULT_BLOCK_SIZE = 1024*64;
+
+  private int blockSize = DEFAULT_BLOCK_SIZE;
+  private boolean read = false;
+  private boolean write = false;
+  private boolean mapped = false;
+  private Path p = null;
+  private Compressor compressor = Compressor.LZ4;
+
+  public CFileBuilder read(){
+    read = true;
+    return this;
+  }
+
+  public CFileBuilder write(){
+    write = true;
+    return this;
+  }
+
+  public CFileBuilder mapped(){
+    mapped = true;
+    return this;
+  }
+
+  public CFileBuilder path(Path p){
+    this.p = p;
+    return this;
+  }
+
+  public CFileBuilder blockSize(int size){
+    blockSize = size;
+    return this;
+  }
+
+  public CFileReader reader() throws IOException {
+    read = true;
+    write = false;
+    return (CFileReader) build();
+  }
+
+  public CFileWriter writer() throws IOException {
+    read = false;
+    write = true;
+    return (CFileWriter) build();
+  }
+
+  public CFileReaderWriter readerWriter() throws IOException {
+    read = true;
+    write = true;
+    return (CFileReaderWriter) build();
+  }
+
+  public CFile build() throws IOException {
+    if(!(read || write))
+      throw new IllegalArgumentException("both read and write cannot be false");
+    if(p == null)
+      throw new IllegalArgumentException("no path specified");
+
+    if(mapped)
+      return buildMapped();
+
+    if(read && write)
+      throw new UnsupportedOperationException("no read writer yet");
+    else if(write)
+      return new LZ4FileWriter(p, blockSize);
+    else
+      return new LZ4CFileReader(p, blockSize);
+  }
+
+  private CFile buildMapped() throws IOException{
+    if(read && write)
+      throw new UnsupportedOperationException("no read writer yet");
+    else if(write)
+      return new LZ4FileWriter(p, blockSize);
+    else
+      return new LZ4MappedCFileReader(p);
+  }
+
+
+
+}

--- a/src/main/java/org/mellowtech/core/io/compress/CFileReader.java
+++ b/src/main/java/org/mellowtech/core/io/compress/CFileReader.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2015 mellowtech.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mellowtech.core.io.compress;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Iterator;
+
+/**
+ * @author msvens
+ * @since 2018-02-12
+ */
+public interface CFileReader extends CFile, Iterable<BlockPointer> {
+
+  default ByteBuffer read(long offset) throws IOException {
+    return read(get(offset));
+  }
+
+  default ByteBuffer read(BlockPointer ptr) throws IOException{
+    ByteBuffer buffer = ByteBuffer.allocate(ptr.getOrigSize());
+    int read = read(ptr, buffer, 0);
+    if(read != ptr.getOrigSize())
+      throw new Error("Size dont match: "+read+" "+ptr.getOrigSize());
+    return buffer;
+  }
+
+  default long next(BlockPointer ptr) throws IOException {
+    return BlockPointer.ByteSize + ptr.getSize();
+  }
+
+  int read(BlockPointer ptr, ByteBuffer bb, int bufferOffset) throws IOException;
+
+  default int read(long fileOffset, ByteBuffer bb, int bufferOffset) throws IOException{
+    return read(get(fileOffset), bb, bufferOffset);
+  }
+
+  default Iterator<BlockPointer> iterator(long offset){
+    return Iterators.fileIterator(fc(), offset);
+  }
+
+  default Iterator<BlockPointer> iterator(){
+    return iterator(0);
+  }
+
+}
+

--- a/src/main/java/org/mellowtech/core/io/compress/CFileReaderWriter.java
+++ b/src/main/java/org/mellowtech/core/io/compress/CFileReaderWriter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015 mellowtech.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mellowtech.core.io.compress;
+
+import java.io.IOException;
+
+/**
+ * @author msvens
+ * @since 2018-02-19
+ */
+public interface CFileReaderWriter extends CFileWriter, CFileReader{
+
+
+  void delete(long offset) throws IOException;
+
+
+
+}

--- a/src/main/java/org/mellowtech/core/io/compress/CFileWriter.java
+++ b/src/main/java/org/mellowtech/core/io/compress/CFileWriter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015 mellowtech.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mellowtech.core.io.compress;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * @author msvens
+ * @since 2018-02-13
+ */
+public interface CFileWriter extends CFile{
+
+
+  default long add(byte[] b, int offset, int length) throws IOException{
+    ByteBuffer bb = ByteBuffer.wrap(b, offset, length);
+    return add(bb);
+  }
+
+  default long add(ByteBuffer bb, int position, int length) throws IOException {
+    return add(bb.duplicate().position(position).limit(position+length));
+  }
+
+  long add(ByteBuffer bb) throws IOException;
+
+}

--- a/src/main/java/org/mellowtech/core/io/compress/Iterators.java
+++ b/src/main/java/org/mellowtech/core/io/compress/Iterators.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2015 mellowtech.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mellowtech.core.io.compress;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.util.Iterator;
+
+/**
+ * @author msvens
+ * @since 2018-02-13
+ */
+class Iterators {
+
+  static Iterator<BlockPointer> bufferIterator(ByteBuffer  bb, long offset){
+    if(offset >= Integer.MAX_VALUE)
+      throw new IndexOutOfBoundsException("offset out of bounds");
+    return new MappedCompressedFileIterator(bb, (int) offset);
+  }
+
+  static Iterator<BlockPointer> fileIterator(FileChannel fc, long offset){
+    return new CompressedFileIterator(fc, offset);
+  }
+
+  static class CompressedFileIterator implements Iterator<BlockPointer> {
+
+    FileChannel fc;
+    long offset;
+
+    public CompressedFileIterator(FileChannel fc, long startOffset) {
+      this.fc = fc;
+      this.offset = startOffset;
+    }
+
+    @Override
+    public boolean hasNext() {
+      try {
+        return offset < fc.size();
+      } catch (IOException e){
+        throw new Error(e);
+      }
+    }
+
+    @Override
+    public BlockPointer next() {
+      if(!hasNext()) return null;
+      try{
+        BlockPointer ptr = BlockPointer.read(fc, offset);
+        offset += BlockPointer.ByteSize + ptr.getSize();
+        return ptr;
+      } catch(IOException e){
+        throw new Error(e);
+      }
+    }
+  }
+
+  static class MappedCompressedFileIterator implements Iterator<BlockPointer> {
+
+    ByteBuffer buffer;
+    int offset = 0;
+    public MappedCompressedFileIterator(ByteBuffer buffer, int startOffset){
+      this.buffer = buffer;
+      this.offset = startOffset;
+
+    }
+
+    @Override
+    public boolean hasNext() {
+      return offset < buffer.capacity();
+    }
+
+    @Override
+    public BlockPointer next() {
+      if(!hasNext()) return null;
+      try {
+        BlockPointer ptr = BlockPointer.read(buffer, offset, offset);
+        offset += BlockPointer.ByteSize + ptr.getSize();
+        return ptr;
+      } catch (IOException e){
+        throw new Error(e);
+      }
+    }
+  }
+
+
+}

--- a/src/main/java/org/mellowtech/core/io/compress/LZ4CFileReader.java
+++ b/src/main/java/org/mellowtech/core/io/compress/LZ4CFileReader.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2015 mellowtech.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mellowtech.core.io.compress;
+
+import net.jpountz.lz4.LZ4Factory;
+import net.jpountz.lz4.LZ4FastDecompressor;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Iterator;
+
+/**
+ * @author msvens
+ * @since 2018-02-13
+ */
+public class LZ4CFileReader extends AbstractCFile implements CFileReader {
+
+  private final LZ4FastDecompressor decomp;
+  private ByteBuffer cbb;
+
+  LZ4CFileReader(Path file, int blockSize) throws IOException{
+    super(file, StandardOpenOption.READ);
+    decomp = LZ4Factory.unsafeInstance().fastDecompressor();
+    cbb = ByteBuffer.allocateDirect(LZ4Factory.unsafeInstance().fastCompressor().maxCompressedLength(blockSize));
+  }
+
+  @Override
+  public FileChannel fc() {
+    return fc;
+  }
+
+  @Override
+  public BlockPointer get(long offset) throws IOException{
+    return BlockPointer.read(fc(), offset);
+  }
+
+  @Override
+  public Iterator<BlockPointer> iterator(long offset) {
+    return Iterators.fileIterator(fc, offset);
+  }
+
+  @Override
+  public int read(BlockPointer ptr, ByteBuffer bb, int bufferOffset) throws IOException{
+    if(bufferOffset + ptr.getOrigSize() > bb.limit())
+      throw new IOException("decompressed data can not fit in the buffer");
+    readData(ptr);
+    decomp.decompress(cbb, 0, bb, bufferOffset, ptr.getOrigSize());
+    return ptr.getOrigSize();
+  }
+
+  private void readData(BlockPointer ptr) throws IOException{
+    if(ptr.getSize() > cbb.capacity())
+      cbb = ByteBuffer.allocateDirect(ptr.getSize());
+    cbb.clear();
+    cbb.limit(ptr.getSize());
+    fc.read(cbb, ptr.getDataOffset());
+    cbb.flip();
+  }
+
+  public String toString(){
+    StringBuilder stringBuilder = new StringBuilder();
+    this.forEach((b) -> {
+      stringBuilder.append(b.toString()); stringBuilder.append('\n');
+    });
+    return stringBuilder.toString();
+  }
+}

--- a/src/main/java/org/mellowtech/core/io/compress/LZ4FileWriter.java
+++ b/src/main/java/org/mellowtech/core/io/compress/LZ4FileWriter.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2015 mellowtech.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mellowtech.core.io.compress;
+
+import net.jpountz.lz4.LZ4Compressor;
+import net.jpountz.lz4.LZ4Factory;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+/**
+ * @author msvens
+ * @since 2018-02-06
+ */
+public class LZ4FileWriter extends AbstractCFile implements CFileWriter {
+
+
+  private final LZ4Compressor compressor;
+  private ByteBuffer compBuffer;
+
+  public static byte[] compress(byte[] input){
+    LZ4Compressor comp = LZ4Factory.unsafeInstance().fastCompressor();
+    return comp.compress(input);
+  }
+
+  LZ4FileWriter(Path file, int defaultBlockSize) throws IOException {
+    super(file, StandardOpenOption.APPEND, StandardOpenOption.CREATE);
+    compressor = LZ4Factory.unsafeInstance().fastCompressor();
+    compBuffer = ByteBuffer.allocateDirect(compressor.maxCompressedLength(defaultBlockSize));
+  }
+
+  @Override
+  public long add(ByteBuffer bb) throws IOException{
+    int maxLength = compressor.maxCompressedLength(bb.limit());
+    if(compBuffer.capacity() < maxLength){
+      compBuffer = ByteBuffer.allocateDirect(maxLength);
+    }
+    compBuffer.clear();
+    compBuffer.position(BlockPointer.ByteSize);
+    compressor.compress(bb, compBuffer);
+    int length = compBuffer.position() - BlockPointer.ByteSize;
+
+    BlockPointer ptr = new BlockPointer(-1, length, bb.limit(), false);
+    ptr.write(compBuffer, 0);
+    compBuffer.flip();
+    long offset = fc.size();
+    fc.write(compBuffer);
+    return offset;
+
+  }
+
+  @Override
+  public FileChannel fc() {
+    return fc;
+  }
+
+
+}

--- a/src/main/java/org/mellowtech/core/io/compress/LZ4MappedCFileReader.java
+++ b/src/main/java/org/mellowtech/core/io/compress/LZ4MappedCFileReader.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015 mellowtech.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mellowtech.core.io.compress;
+
+import net.jpountz.lz4.LZ4Factory;
+import net.jpountz.lz4.LZ4FastDecompressor;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Iterator;
+
+/**
+ * @author msvens
+ * @since 2018-02-13
+ */
+public class LZ4MappedCFileReader extends AbstractCFile implements CFileReader {
+
+  private final MappedByteBuffer mbb;
+  private final LZ4FastDecompressor decomp;
+
+  LZ4MappedCFileReader(Path file) throws IOException{
+    super(file, StandardOpenOption.READ);
+    if(fc.size() > Integer.MAX_VALUE)
+      throw new IOException("file to large to map in one buffer");
+    mbb = fc.map(FileChannel.MapMode.READ_ONLY, 0, (int) fc.size());
+    decomp = LZ4Factory.unsafeInstance().fastDecompressor();
+  }
+
+  @Override
+  public FileChannel fc() {
+    return fc;
+  }
+
+  @Override
+  public BlockPointer get(long offset) throws IOException{
+    return BlockPointer.read(mbb, (int) offset, offset);
+  }
+
+  @Override
+  public Iterator<BlockPointer> iterator(long offset) {
+    return Iterators.bufferIterator(mbb, offset);
+  }
+
+  @Override
+  public int read(BlockPointer ptr, ByteBuffer bb, int bufferOffset) throws IOException{
+    if(bufferOffset + ptr.getOrigSize() > bb.limit())
+      throw new IOException("decompressed data can not fit in the buffer");
+    decomp.decompress(mbb, (int) ptr.getOffset()+BlockPointer.ByteSize,
+        bb, bufferOffset, ptr.getOrigSize());
+    return ptr.getOrigSize();
+  }
+
+  public String toString(){
+    StringBuilder stringBuilder = new StringBuilder();
+    this.forEach((b) -> {
+      stringBuilder.append(b.toString()); stringBuilder.append('\n');
+    });
+    return stringBuilder.toString();
+  }
+}

--- a/src/test/java/org/mellowtech/core/io/compress/CFileReaderTemplate.java
+++ b/src/test/java/org/mellowtech/core/io/compress/CFileReaderTemplate.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2015 mellowtech.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mellowtech.core.io.compress;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author msvens
+ * @since 2018-02-25
+ */
+abstract class CFileReaderTemplate extends CFileTemplate {
+
+
+  @FunctionalInterface
+  interface DoRead{
+    void read(CFileReader r) throws IOException;
+  }
+
+  CFileWriter cFileWriter(){return (CFileWriter) cFile;}
+  byte[] comp;
+
+
+  abstract String fName();
+
+  CFile init(Path name) throws IOException {
+    return initWriter(name);
+  }
+
+  abstract CFileWriter initWriter(Path name) throws IOException;
+  abstract CFileReader initReader(Path name) throws IOException;
+  abstract byte[] compressed(byte[] input);
+
+  @BeforeEach
+  void setup() throws Exception {
+    super.setup();
+    comp = compressed(input.array());
+  }
+
+  CFileReader getReader(){
+    try {
+      return initReader(absFile());
+    } catch(IOException e){
+      throw new Error(e);
+    }
+  }
+
+  void addOne() throws IOException{
+    input.clear();
+    cFileWriter().add(input);
+  }
+
+  void addDbl() throws IOException{
+    dblInput.clear();
+    cFileWriter().add(dblInput);
+  }
+
+  void add(int times) throws IOException {
+    while(times-- > 0)
+      addOne();
+  }
+
+  void doReader(DoRead c) throws IOException{
+    CFileReader reader = getReader();
+    c.read(reader);
+    reader.close();
+  }
+
+
+  @Nested
+  @DisplayName("CFileReader")
+  class CFileWriterTest {
+
+    @Test
+    @DisplayName("Get One")
+    void getOne() throws IOException {
+      addOne();
+      doReader((reader) -> {
+        BlockPointer bp = reader.get(0);
+        assertEquals(comp.length, bp.getSize());
+        assertEquals(input.capacity(), bp.getOrigSize());
+      });
+    }
+
+    @Test
+    @DisplayName("Get Next")
+    void next() throws IOException {
+      addOne();
+      addOne();
+      doReader(reader -> {
+        BlockPointer bp = reader.get(0);
+        BlockPointer bp1 = reader.get(reader.next(bp));
+        assertEquals(bp.getSize(), bp1.getSize());
+      });
+    }
+
+    @Test
+    @DisplayName("Read One")
+    void readOne() throws IOException {
+      addOne();
+      doReader(reader -> {
+        ByteBuffer bb = reader.read(0);
+        assertArrayEquals(input.array(),bb.array());
+      });
+    }
+
+    @Test
+    @DisplayName("Read Five")
+    void readFive() throws IOException {
+      add(5);;
+      doReader(reader -> {
+        long offset = 0;
+        for(int i = 0; i < 5; i++){
+          BlockPointer ptr = reader.get(offset);
+          offset = reader.next(ptr);
+          ByteBuffer bb = reader.read(ptr);
+          assertArrayEquals(input.array(), bb.array());
+        }
+      });
+    }
+
+    @Test
+    @DisplayName("Different Sized inputs")
+    void readDifferent() throws IOException {
+      addOne();
+      addDbl();
+      addOne();
+      addDbl();
+      doReader(reader -> {
+        Iterator<BlockPointer> iter = reader.iterator();
+        for(int i = 0; i < 4; i++){
+          BlockPointer ptr = iter.next();
+          ByteBuffer bb = reader.read(ptr);
+          if(i % 2 == 0) { //normal input
+            assertEquals(input.capacity(), ptr.getOrigSize());
+            assertArrayEquals(input.array(), bb.array());
+          } else { //double input
+            assertEquals(dblInput.capacity(), ptr.getOrigSize());
+            assertArrayEquals(dblInput.array(), bb.array());
+          }
+        }
+      });
+    }
+
+    @Test
+    @DisplayName("Empty Iterator")
+    void emptyIterator() throws IOException {
+      doReader(reader -> {
+        Iterator<BlockPointer> iter = reader.iterator();
+        assertFalse(iter.hasNext());
+      });
+    }
+
+    @Test
+    @DisplayName("10 Iterator")
+    void tenIterator() throws IOException {
+      add(10);
+      doReader(reader -> {
+        Iterator<BlockPointer> iter = reader.iterator();
+        for(int i = 0; i < 10; i++){
+          assertFalse(iter.next().isDeleted());
+        }
+        assertFalse(iter.hasNext());
+      });
+    }
+
+
+
+  }
+
+
+}

--- a/src/test/java/org/mellowtech/core/io/compress/CFileTemplate.java
+++ b/src/test/java/org/mellowtech/core/io/compress/CFileTemplate.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2015 mellowtech.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mellowtech.core.io.compress;
+
+import org.junit.jupiter.api.*;
+import org.mellowtech.core.TestUtils;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.*;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * @author msvens
+ * @since 2018-02-25
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class CFileTemplate {
+
+  static int DEFAULT_BLOCK_SIZE = 1024*64;
+
+  final URL url = this.getClass().getResource("/com/mellowtech/core/sort/longText.txt");
+  final String dir = "compresstests";
+  CFile cFile;
+  ByteBuffer input;
+  ByteBuffer dblInput;
+
+  abstract String fName();
+  abstract CFile init(Path name) throws IOException;
+
+  Path absDir() {
+    return TestUtils.getAbsolutePath(dir);
+  }
+
+  Path absFile() {
+    return TestUtils.getAbsolutePath(dir + "/" + fName());
+  }
+
+  void createFile() throws IOException{
+    File f = absFile().toFile();
+    if(!f.exists()) f.createNewFile();
+  }
+
+
+
+  void loadInputData(){
+    try {
+      FileInputStream is = new FileInputStream(url.getFile());
+      byte[] bytes = is.readAllBytes();
+      input = ByteBuffer.wrap(bytes);
+      dblInput = ByteBuffer.allocate(bytes.length*2);
+      dblInput.put(bytes);
+      dblInput.put(bytes);
+    } catch(IOException e){
+      throw new Error("could not load input data");
+    }
+  }
+
+
+  @BeforeAll
+  void createDir(){
+    if(Files.exists(absDir()))
+      TestUtils.deleteTempDir(dir);
+    TestUtils.createTempDir(dir);
+  }
+
+  @AfterAll
+  void deleteDir(){
+    TestUtils.deleteTempDir(dir);
+  }
+
+  @BeforeEach
+  void setup() throws Exception {
+    createFile();
+    cFile = init(absFile());
+    loadInputData();
+  }
+
+  @AfterEach
+  void after() throws Exception {
+    cFile.close();
+    cFile.delete();
+  }
+
+  @Nested
+  @DisplayName("Empty CFile")
+  class EmptyCFile {
+    @Test
+    @DisplayName("Opened")
+    void opened() {
+      assertTrue(cFile.isOpen());
+    }
+
+    @Test
+    @DisplayName("Closed")
+    void closed() throws IOException {
+      cFile.close();
+      assertFalse(cFile.isOpen());
+    }
+
+    @Test
+    @DisplayName("Multiple Closed")
+    void closed2() throws IOException {
+      cFile.close();
+      cFile.close();
+      assertFalse(cFile.isOpen());
+    }
+
+    @Test
+    @DisplayName("Throw exception when reading a block")
+    void getBlock(){
+      assertThrows(Exception.class, () -> {
+        cFile.get(0);
+      });
+    }
+  }
+
+
+
+
+}

--- a/src/test/java/org/mellowtech/core/io/compress/CFileWriterTemplate.java
+++ b/src/test/java/org/mellowtech/core/io/compress/CFileWriterTemplate.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2015 mellowtech.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mellowtech.core.io.compress;
+
+import org.junit.jupiter.api.*;
+import org.mellowtech.core.TestUtils;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author msvens
+ * @since 2018-02-25
+ */
+abstract class CFileWriterTemplate extends CFileTemplate {
+
+  CFileWriter cFileWriter(){return (CFileWriter) cFile;}
+
+
+  abstract String fName();
+  abstract CFile init(Path name) throws IOException;
+
+
+  @Nested
+  @DisplayName("CFileWriter")
+  class CFileWriterTest {
+    @Test
+    @DisplayName("Add One")
+    void addOne() throws IOException{
+      long pos = cFileWriter().add(input);
+      assertEquals(0, pos);
+    }
+    @Test
+    @DisplayName("Add Two")
+    void addTwo() throws IOException{
+      long pos = cFileWriter().add(input);
+      input.clear();
+      assertEquals(0, pos);
+      pos = cFileWriter().add(input);
+      assertTrue(pos > 0);
+    }
+    @Test
+    @DisplayName("Add 10")
+    void addTen() throws IOException{
+      //input.clear();
+      long pos = cFileWriter().add(input);
+      input.clear();
+      assertEquals(0, pos);
+      long length = cFileWriter().add(input);
+      pos = length;
+      for(int i = 0; i < 8; i++){
+        input.clear();
+        long p1 = cFileWriter().add(input);
+        assertEquals(length,p1 - pos);
+        pos = p1;
+      }
+    }
+
+
+
+
+  }
+
+
+
+
+}

--- a/src/test/java/org/mellowtech/core/io/compress/LZ4CFileReaderTest.java
+++ b/src/test/java/org/mellowtech/core/io/compress/LZ4CFileReaderTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015 mellowtech.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mellowtech.core.io.compress;
+
+import org.junit.jupiter.api.DisplayName;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+
+/**
+ * @author msvens
+ * @since 2018-03-24
+ */
+@DisplayName("LZ4 CFileReader")
+public class LZ4CFileReaderTest extends CFileReaderTemplate {
+
+
+  @Override
+  String fName() {
+    return "lz4CFileReader.lzc";
+  }
+
+  @Override
+  CFileWriter initWriter(Path name) throws IOException {
+    return new LZ4FileWriter(name, DEFAULT_BLOCK_SIZE);
+  }
+
+  @Override
+  CFileReader initReader(Path name) throws IOException {
+    return new LZ4CFileReader(name, DEFAULT_BLOCK_SIZE);
+  }
+
+  @Override
+  byte[] compressed(byte[] input) {
+    return LZ4FileWriter.compress(input);
+  }
+
+
+}

--- a/src/test/java/org/mellowtech/core/io/compress/LZ4CFileWriterTest.java
+++ b/src/test/java/org/mellowtech/core/io/compress/LZ4CFileWriterTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 mellowtech.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mellowtech.core.io.compress;
+
+import org.junit.jupiter.api.DisplayName;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * @author msvens
+ * @since 2018-03-24
+ */
+@DisplayName("LZ4 CFileReader")
+public class LZ4CFileWriterTest extends CFileWriterTemplate {
+
+
+  @Override
+  String fName() {
+    return "lz4CFileWriter.lzc";
+  }
+
+  @Override
+  CFile init(Path name) throws IOException {
+    return new LZ4FileWriter(name, DEFAULT_BLOCK_SIZE);
+  }
+
+
+}


### PR DESCRIPTION
Compressed block file with basic testing. Current implementation uses LZ4. The reason for adding compressed block files is to use for read only disc maps